### PR TITLE
Align role titles with LinkedIn and state freelance status

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -9,10 +9,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
     <div class="prose" style="color: var(--ink-dim); font-size: 1.05rem;">
       <p>
-        I'm a senior software engineer on the device team at SiriusXM, building
-        backend services in Scala with Cats Effect, running on AWS
-        (Lambda, DynamoDB, Kinesis, Secrets Manager, CDK). I work remotely
-        from Rome.
+        I'm a freelance software engineer, currently technical lead on the
+        device team at SiriusXM, building backend services in Scala with
+        Cats Effect, running on AWS (Lambda, DynamoDB, Kinesis, Secrets
+        Manager, CDK). I work remotely from Rome.
       </p>
       <p>
         Before that I was at Kaluza (OVO Energy) in the UK, where I designed
@@ -35,11 +35,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="spec-sheet">
       <div class="spec-row">
         <div class="spec-key">Now</div>
-        <div class="spec-val">Senior Software Engineer — <span class="dim">SiriusXM, User Services / Device team</span></div>
+        <div class="spec-val">Technical Lead (contract) — <span class="dim">SiriusXM, User Services / Device team</span></div>
       </div>
       <div class="spec-row">
         <div class="spec-key">Prior</div>
-        <div class="spec-val">Software Engineer — <span class="dim">Kaluza / OVO Energy, UK — GraphQL-over-Kafka API architecture</span></div>
+        <div class="spec-val">Technical Lead — <span class="dim">Kaluza / OVO Energy, UK — GraphQL-over-Kafka API architecture</span></div>
       </div>
       <div class="spec-row">
         <div class="spec-key">Earlier</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const dateFmt = new Intl.DateTimeFormat('en-GB', { year: 'numeric', month: 'shor
     <div class="spec-sheet" role="group" aria-label="Quick facts">
       <div class="spec-row">
         <div class="spec-key">Role</div>
-        <div class="spec-val">Senior Software Engineer, <span class="dim">SiriusXM — User Services / Device team</span></div>
+        <div class="spec-val">Technical Lead (contract), <span class="dim">SiriusXM — User Services / Device team</span></div>
       </div>
       <div class="spec-row">
         <div class="spec-key">Stack</div>


### PR DESCRIPTION
The site described the current role at SiriusXM as **Senior Software Engineer** and the previous one at Kaluza as **Software Engineer**. Both were **Technical Lead** — the titles were understating the actual roles, and they contradicted LinkedIn.

The site also never mentioned freelancing anywhere, so a visitor reasonably read the SiriusXM role as full-time employment rather than a contract — which works against the site's purpose as a freelancer's landing page.

**Changes**
- `index.astro` — Role: `Senior Software Engineer` → `Technical Lead (contract)`
- `about.astro` — intro paragraph now opens with "I'm a freelance software engineer, currently technical lead on the device team at SiriusXM"
- `about.astro` — Now: `Senior Software Engineer` → `Technical Lead (contract)`
- `about.astro` — Prior: `Software Engineer` → `Technical Lead` (Kaluza / OVO Energy)

Copy-only: no markup, styling or structural changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)