### PR TITLE
Restore blog post bodies lost in the Astro migration

### DIFF
--- a/src/content/blog/2010-04-21-rest-method-override-filter.md
+++ b/src/content/blog/2010-04-21-rest-method-override-filter.md
@@ -5,10 +5,96 @@ tags: ["java", "rest"]
 excerpt: "A servlet filter to work around clients that can only send GET/POST by overriding the HTTP method."
 ---
 
-> Migrated from the old Hugo site. Original: [filippodeluca.com/posts/2010-04-21-rest-method-override-filter](http://filippodeluca.com/posts/2010-04-21-rest-method-override-filter/)
+The current trend of developing web applications based on REST service can find an obstacle in the proxy and firewall 
+configurations: most of these drop requests other than the `GET` and `POST`. The best practices of REST API design involve 
+using all HTTP methods to describe the actions, rather than changing the URI, i.e., The URI should identify the resources, not the actions.
 
-<!--
-  TODO: paste the original post body here. The old page could not be
-  fetched automatically during migration — copy the content from the
-  Wayback Machine or your old repo's source Markdown/HTML.
--->
+A URI like `http://example.com/users/delete/6` is an example of how somebody should represent REST API resources. It should be
+`http://example.com/users/6` and handle the DELETE method to remove the user with id `6`.
+
+A clever solution to keep the API clean is to override the original method with one specified in a request header. So that a 
+`POST` method can act as the `PUT` or `DELETE` methods. The `X-HTTP-Method-Override` is the commonly used
+header for this purpose.
+
+## The java source code:
+
+```java
+
+	public class MethodOverrideFilter implements Filter {
+	
+		public static final String HEADER_PARAM = "methodOverrideHeader";
+		
+		public static final String DEFAULT_HEADER = "X-HTTP-Method-Override";
+		
+		private String header = DEFAULT_HEADER;
+		
+		public void init(FilterConfig filterConfig) throws ServletException {
+		
+		    header = filterConfig.getInitParameter(HEADER_PARAM);
+		    if(StringUtils.isBlank(header)) {
+		      header = DEFAULT_HEADER;
+		    }
+		
+		}
+		
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		
+			ServletRequest filteredRequest = request;
+			
+			if(request instanceof HttpServletRequest) {
+			
+			  HttpServletRequest httpRequest = (HttpServletRequest)request;
+			  filteredRequest = new MethodOverrideHttpServletRequestDecorator(
+				httpRequest, 
+				header
+			  );
+			}
+			
+			chain.doFilter(filteredRequest, response);
+		}
+	
+		public void destroy() {
+			// Empty
+		}
+	
+		private class MethodOverrideHttpServletRequestDecorator extends HttpServletRequestWrapper {
+		
+			public static final String DEFAULT_HEADER = "X-HTTP-Method-Override";
+			
+			private final String methodOverrideHeader;
+			
+			private transient String method;
+			
+			public MethodOverrideHttpServletRequestDecorator(HttpServletRequest request, String methodOverrideHeader) {
+				super(request);
+				this.methodOverrideHeader = methodOverrideHeader;
+			}
+			
+			@Override
+			public String getMethod() {
+			
+				if(method==null) {
+					method = resolveMethod();
+				}
+				
+				return method;
+			}
+			
+			protected String resolveMethod() {
+			
+				String headerValue = getHeader(methodOverrideHeader);
+				
+				if(headerValue!=null) {
+					return headerValue;
+				}
+				else {
+					return super.getMethod();
+				}
+			}
+		
+		}
+	}
+
+```
+
+You can find the source code at [https://gist.github.com/923414].

--- a/src/content/blog/2012-10-15-gwt-rpc-best-practices.md
+++ b/src/content/blog/2012-10-15-gwt-rpc-best-practices.md
@@ -5,10 +5,180 @@ tags: ["java", "gwt"]
 excerpt: "Lessons learned structuring RPC services in Google Web Toolkit applications."
 ---
 
-> Migrated from the old Hugo site. Original: [filippodeluca.com/posts/2012-10-15-gwt-rpc-best-practices](http://filippodeluca.com/posts/2012-10-15-gwt-rpc-best-practices/)
+The Google Web Toolkit (GWT) allows you write plain java code, and then to translate it 
+to client-side javascript code. Therefore it permits you to reuse your domain objects in the 
+client side. This promise is amazing, but it isn't the whole true: using 
+GWT without be aware of the transformation can produce a poor performance and, 
+worst, unmaintainable project with disastrous results for your business.
 
-<!--
-  TODO: paste the original post body here. The old page could not be
-  fetched automatically during migration — copy the content from the
-  Wayback Machine or your old repo's source Markdown/HTML.
--->
+I would like to spend some time to write a post about the best practices I 
+have learnt using GWT and which common pitfalls to avoid.
+
+When I have started to use GWT, the first problem I encountered was the 
+development of the RPC services:
+ 
+1. They need two interfaces.
+2. They should be implemented by java Servlet.
+3. The serialization of objects is a difficult to manage.
+4. Their interface should not follow the java common best practices. 
+
+The 1st point is solvable using the `maven-gwt-plugin`: this will generate the 
+Async interface as well the Servlet mapping on the `web.xml` descriptor 
+(it doesn't work well with generics actually).
+
+The drawbacks of the 2nd point instead is that if you are using Spring, the Servlet 
+are instantiated outside the Spring context; you cannot apply any aspect on them.
+(e.g. they can't be transactional). If you want the GWT service to be managed  
+by the Spring context, you need to create two instances of the same interface:
+
+* A Spring bean
+* A Servlet that delegates all method implementations to the Spring bean.
+
+This is a possible implementation of that:
+```java
+public abstract class GWTService {
+
+    protected HttpServletRequest currentRequest() {
+        return GWTThreadLocals.instance().getRequest();
+    }
+
+    protected HttpServletResponse currentResponse() {
+        return GWTThreadLocals.instance().getResponse();
+    }
+}
+
+public final class GWTThreadLocals {
+
+    private static final GWTThreadLocals INSTANCE = new GWTThreadLocals();
+
+    protected ThreadLocal<HttpServletRequest> perThreadRequest;
+    protected ThreadLocal<HttpServletResponse> perThreadResponse;
+
+    private GWTThreadLocals() {
+        perThreadRequest = new ThreadLocal<HttpServletRequest>();
+        perThreadResponse = new ThreadLocal<HttpServletResponse>();
+    }
+
+    public static GWTThreadLocals instance() {
+        return INSTANCE;
+    }
+
+    public void setRequest(HttpServletRequest request) {
+        perThreadRequest.set(request);
+    }
+
+    public HttpServletRequest getRequest() {
+        return perThreadRequest.get();
+    }
+
+    public void setResponse(HttpServletResponse response) {
+        perThreadResponse.set(response);
+    }
+
+    public HttpServletResponse getResponse() {
+        return perThreadResponse.get();
+    }
+}
+
+public abstract class GWTRemoteServiceServlet extends RemoteServiceServlet {
+
+    @Override
+    protected void onBeforeRequestDeserialized(String serializedRequest) {
+        super.onBeforeRequestDeserialized(serializedRequest);
+        setGwtThreadLocals();
+    }
+
+    protected void setGwtThreadLocals() {
+        GWTThreadLocals.instance().setRequest(getThreadLocalRequest());
+        GWTThreadLocals.instance().setResponse(getThreadLocalResponse());
+    }
+}
+```
+
+So if we need to implement a GWT service interface, we have to extend 
+`GWTService` and implement our interface. Then we have to write our Servlet 
+that extends `GWTRemoteServiceServlet` and implements the same interface, delegating 
+all method implementations to the Spring bean.
+
+This is the example for a `ContactService` interface:
+
+```java
+@RemoteServiceRelativePath("ContactService")
+public interface ContactService extends RemoteService {
+
+  ArrayList<Contact> findByName(String name);
+
+}
+
+@Service("contactService")
+public class ContactServiceImpl extends GWTService implements ContactService {
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public ArrayList<Contact> findByName(String name) {
+
+       // Implementation calling the DB or whatever do you want
+       return new ArrayList<Contact>();
+    }
+}
+
+public class ContactServiceServlet extends GWTServiceServlet implements ContactService {
+
+    private ContactService delegate;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+
+        delegate = getRequiredWebApplicationContext(config.getServletContext()).getBean(ContactService.class);
+    }
+
+
+    @Override
+    public ArrayList<Contact> findByName(String name) {
+       // Call the delegate implementation
+       return delegate.findByName(name);
+    }
+}
+```
+
+Writing this code for each service is a very boring job of course, but your IDE 
+can do it for you.
+
+How you can notice the {{ContactInterface}} expose the {{ArrayList}} concrete type
+instead of the {{List}} interface. It is about the `4`, exposing {{List}} makes
+GWT creating one snipped of code for each possible implementation of {{List}}. This
+will generate a oversize codebase and a longer compilation time. Indeed it is against
+any Java common best practice, but you have to keep in mind that GWT is not Java.
+
+About the serialization of object:
+
+* They should implement Serializable or IsSerializable
+* They should have an empty default constructor
+* All transient or final(so crazy) fields will be ignored.
+* All dependent object should follow the same rules.
+
+Of course GWT should know the codebase of the type for each dependent not final/transient
+field. The trick is put the source as dependency of the maven module contains the GWT plugin.
+However it is not enough because not all standard java classes are supported (no Calendar for example),
+so also if you include a lib source code, unlikely will be supported. Some libs offers a separate
+module for the GWT support, as Google Guava does. But they are not so common. Alternatively you
+can write the serialization for a particular class yourself. However is not so trivial.
+
+How we have seen there is no simple solutions for the `4`, having a serializable object, is 
+complex and unlikely good integrated in our domain. If for example we are using Hibernate as
+ORM, serializing an Hibernate entity is the worst thing you can do. It will serialize your whole
+DB in the worst case. However in many case you have to deep copy the object because GWT is not
+able to serialize the Hibernate custom collections. And usually you don't need them in client side.
+
+At the end using GWT RPC require to write a GWT service layer with its own domain
+objects. They will likely contain already preprocessed data, like the formatted date
+(no joda time on GWT, neither Calendar). At the end of the day, the promise to use 
+your domain object in the client side is a lie.
+
+In the next post I will describe a way to use a JSON REST api with GWT.
+
+The complete code is available at [GWT RPC Spring Scaffolding gist](https://gist.github.com/3902429).
+
+

--- a/src/content/blog/2012-11-02-pimping-jsoup.md
+++ b/src/content/blog/2012-11-02-pimping-jsoup.md
@@ -5,10 +5,104 @@ tags: ["java", "html-parsing"]
 excerpt: "Extending JSoup for smoother HTML scraping and manipulation in Java."
 ---
 
-> Migrated from the old Hugo site. Original: [filippodeluca.com/posts/2012-11-02-pimping-jsoup](http://filippodeluca.com/posts/2012-11-02-pimping-jsoup/)
+I started to develop a web crawler part of a bigger project, then I have to 
+choice what kind of HTML parser library I have to use. I have used NekoHTML
+in the past and it was pretty good but it doesn't have any helper to select
+the DOM elements, you have o use the XPath, very flexible but not so easy.
 
-<!--
-  TODO: paste the original post body here. The old page could not be
-  fetched automatically during migration — copy the content from the
-  Wayback Machine or your old repo's source Markdown/HTML.
--->
+I have found [JSoup](http://jsoup.org/) to be very cool library, its code is 
+well written, clean and the interface is powerful. I love it. I was writing 
+a Scala crawler so beside the [JSoup](http://jsoup.org/) interface is pretty 
+cool, it is very javish, I prefer to have a better integration with Scala, so 
+I started my first [Pimp My Library](http://www.artima.com/weblogs/viewpost.jsp?thread=179766) pattern.
+
+Let the code talk:
+
+```java
+object Jsoup extends Jsoup
+
+trait Jsoup {
+
+  protected[Jsoup] def withDocument[T](url: String)(d: Document => T) = {
+    try {
+      Right(d(JJSoup.connect(url).get()))
+    }
+    catch {
+      case e: IOException => Left(e)
+    }
+  }
+
+  implicit def enrichNode(n: Node) = new RichNode(n)
+
+  implicit def enrichElement(x: Element) = new RichElement(x)
+
+  implicit def enrichDocument(x: Document) = new RichDocument(x)
+
+  implicit def enrichElements(xs: Elements) = new RichElements(xs)
+
+}
+
+class RichNode(value: Node) {
+
+  def nextSibling: Option[Node] = value.nextSibling match {
+    case null => None
+    case x => Some(x)
+  }
+
+}
+
+
+class RichElement(value: Element) extends RichNode(value) {
+
+  def getElementById(id: String): Option[Element] = value.getElementById(id) match {
+    case null => None
+    case x => Some(x)
+  }
+
+  def getElementsByTag(tag: String): Iterable[Element] = 
+	Jsoup.enrichElements(value.getElementsByTag(tag))
+
+  def getElementsByClass(tag: String): Iterable[Element] = 
+	Jsoup.enrichElements(value.getElementsByClass(tag))
+
+  def getElementsByAttribute(tag: String): Iterable[Element] = 
+	Jsoup.enrichElements(value.getElementsByAttribute(tag))
+
+  def getElementsByAttributeStarting(tag: String): Iterable[Element] = 
+	Jsoup.enrichElements(value.getElementsByAttributeStarting(tag))
+
+  def getElementsByAttributeValue(k: String, v: String): Iterable[Element] = 
+	Jsoup.enrichElements(value.getElementsByAttributeValue(k, v))
+
+  def apply(name: String): Option[String] = Option(value.attr(name))
+
+}
+
+class RichDocument(value: Document) extends RichElement(value) {
+
+  def head = value.head match {
+    case null => None
+    case x => Some(x)
+  }
+
+  def body = value.body match {
+    case null => None
+    case x => Some(x)
+  }
+
+  def select(query: String) = new RichElements(value.select(query))
+
+}
+
+class RichElements(target: Elements) extends Iterable[Element] {
+
+  def iterator: Iterator[Element] = {
+    target.asScala.iterator
+  }
+
+}
+```
+
+The code is available at [https://github.com/filosganga/ssoup]. 
+
+Happy coding!

--- a/src/content/blog/2013-10-24-round-robin-iterable.md
+++ b/src/content/blog/2013-10-24-round-robin-iterable.md
@@ -5,10 +5,117 @@ tags: ["java", "algorithms"]
 excerpt: "A small Iterable implementation for round-robin traversal over a collection of collections."
 ---
 
-> Migrated from the old Hugo site. Original: [filippodeluca.com/posts/2013-10-24-round-robin-iterable](http://filippodeluca.com/posts/2013-10-24-round-robin-iterable/)
+I had the task of collecting 50 images from a third-party supplier. Each record 
+has a set of albums, an ordered list of images, and a set of featured them picked
+from the albums. We want to collect 50 images, starting from the feature and then
+going through the albums in a round-robin fashion (the first for each album, the second, and so on). The album may have different sizes.
 
-<!--
-  TODO: paste the original post body here. The old page could not be
-  fetched automatically during migration — copy the content from the
-  Wayback Machine or your old repo's source Markdown/HTML.
--->
+So if we have the feed containing these image id:
+
+```java
+featuredImages: [1, 5, 4, 9]
+albumOne: [1, 2, 3, 4]
+albumTwo: [5, 6, 7, 8, 9, 10]
+albumThree: [11]
+albumFour: [12, 13, 14]
+```
+
+And we want to collect 10 images we got:
+
+```java
+images: [1, 5, 4, 9, 5, 11, 12, 2, 6, 13]
+```
+
+The most simple solution I think, has been to use [Guava Iterables](http://docs.guava-libraries.googlecode.com/git-history/release/javadoc/com/google/common/collect/Iterables.html)
+to limit the image to 10. 
+
+```java
+Iterable<Image> images = limit(concat(featuredImages, albumImages), 10)
+```
+
+But how can I obtain the albumImages in the right order (round-robin)? I need a
+custom {{Iterator}}, then I have written this one:
+
+```java
+public class RoundRobinIterable<T> implements Iterable<T> {
+ 
+    private final Iterable<Iterable<T>> iterables;
+ 
+    public RoundRobinIterable(Iterable<Iterable<T>> iterables) {
+ 
+        checkNotNull(iterables);
+ 
+        this.iterables = iterables;
+    }
+ 
+    @Override
+    public Iterator<T> iterator() {
+ 
+        final Iterator<Iterator<T>> it = cycle(filter(
+                FluentIterable.from(iterables)
+                .transform(RoundRobinIterable.<T>iteratorFn())
+                .toList(),
+                hasNextPr()
+        ));
+ 
+        return new UnmodifiableIterator<T>() {
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+ 
+            @Override
+            public T next() {
+                return it.next().next();
+            }
+        };
+ 
+    }
+ 
+    private enum HasNext implements Predicate<Iterator<?>> {
+        INSTANCE;
+ 
+        @Override
+        public boolean apply(Iterator<?> input) {
+            return input.hasNext();
+        }
+    }
+ 
+    private static Predicate<Iterator<?>> hasNextPr() {
+        return HasNext.INSTANCE;
+    }
+ 
+    private static <T> Function<Iterable<T>, Iterator<T>> iteratorFn() {
+        return new Function<Iterable<T>, Iterator<T>>() {
+            @Override
+            public Iterator<T> apply(Iterable<T> input) {
+                return input.iterator();
+            }
+        };
+    }
+}
+```
+
+It leverages on the lazy evaluation of {{Iterator.hasNext()}}, so the 
+{{Iterator<Iterator<T>>}} will cycle over the given iterator, skipping the empty
+iterators on the fly.
+
+And that's it. Well, actually, no, we want a test, don't we?
+
+```java
+public class RoundRobinIterableTest {
+ 
+    @Test
+    public void iteratorShouldBeWorkAsExpected() {
+ 
+        List<Integer> numbers = newArrayList(RoundRobinIterable.of(asList(1,2,3,9), asList(4,5), asList(6,7,8)));
+        List<Integer> expected = newArrayList(1, 4, 6, 2, 5, 7, 3, 8, 9);
+ 
+        assertThat(numbers, equalTo(expected));
+    }
+}
+```
+
+The full code is available at the [RoundRobinIterable.java gist](https://gist.github.com/filosganga/7134943)
+
+Happy coding!

--- a/src/content/blog/2015-02-17-docker-maven-plugin.md
+++ b/src/content/blog/2015-02-17-docker-maven-plugin.md
@@ -1,0 +1,142 @@
+---
+title: "Docker maven plugin"
+date: 2015-02-17
+tags: ["java", "docker", "build"]
+excerpt: "Making the Maven build produce a Docker image as its artifact instead of a jar, and what that changes about delivery."
+---
+
+As Docker is gathering more interest from the big IT companies, it seems to be a perfect way to 
+delivery the applications to the production environemnt. If until now the maven artifct was the 
+jar or war, now it looks natural the artifact should be the docker image. In fact this strategy
+is not new: Netflix was, and still does, deliver its application, as AMI images tagged with
+the verion and other build informations.
+
+With Docker this approach become easier so that everyone can adopt it without the big Netflix 
+infrastructure. The question is now, how to make our build generate the docker imag for us? If
+we are using maven, the Spotify [docker-maven-plugin](https://github.com/spotify/docker-maven-plugin) 
+comes in handy here. it is able to build an image, tag it and push it on a public or private 
+docker registry.
+
+It provides three goals:
+ 
+ - build
+ - tag
+ - push
+ 
+It is possible to push also from the tag or the build goal, and it is possible to tag also from 
+the build goal. It uses under the hood the spotify [docker-client](https://github.com/spotify/docker-client) library backed by Jersey client.
+
+Let take a look how to apply this plugin to the Maven lifecycle: the phases we need are three: 
+ 
+ - package
+ - install
+ - deploy
+ 
+First of all we have to add the plugin block under our build/plugins block:
+
+```xml
+<plugin>
+  <groupId>com.spotify</groupId>
+  <artifactId>docker-maven-plugin</artifactId>
+  <version>0.1.2</version>
+  <executions>
+    <!-- ... -->
+  </executions>
+</plugin>  
+```
+
+
+Similary for what happen for the jar, we would like our artifact to be built as part of the package
+phase. So lets bind an execution to the package phase. Assuming that the build is generating a packaged
+application myapp.tar.gz and that we have our Dockerfile in /src/main/docker: 
+
+```xml
+<execution>
+    <id>build-docker-image</id>
+    <phase>package</phase>
+    <goals>
+        <goal>build</goal>
+    </goals>
+
+    <configuration>
+        <imageName>myuser/myapp</imageName>
+        <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+        <!-- The `tagInfoFile` is required apparently because of a bug in the `tag` mojo. -->
+        <tagInfoFile>${project.build.directory}/docker_image_info.json</tagInfoFile>
+        <resources>
+            <resource>
+                <targetPath>/</targetPath>
+                <directory>${project.build.directory}</directory>
+                <include>myapp.tar.gz</include>
+            </resource>
+        </resources>
+    </configuration>
+
+</execution>
+```
+
+The resources block can be used to add all the resources we need in our docker image. There is 
+also an alternative way to build image, using th xml to define the docker commands, but I will
+prefere using the external Dockerfile, as it looks more familiar to the people accustomised to
+Docker already.
+
+At the eand of the package phase we will have the `myuser/myapp:latest` image built on docker.
+however we want our image taggeg with the project version, don't we? We can achieve it in the 
+same `build` goal but in my opinion, the install phase is a better fit for that.
+
+Before the install phase, we can actually use the generated image for our functional or 
+integration tests, maybe using the `docker-client` Spotify library. How the install phase 
+looks like? here it is:
+
+```xml
+<execution>
+    <id>tag-docker-image</id>
+    <phase>install</phase>
+    <goals>
+        <goal>tag</goal>
+    </goals>
+
+    <configuration>
+        <tagInfoFile>${project.build.directory}/docker_image_info.json</tagInfoFile>
+        <image>myuser/myapp</image>
+        <newName>myuser/myapp:${project.version}</newName>
+    </configuration>
+</execution>
+```
+
+The `image` parameter should match with the `build` goal `imageName` parameter, if the tag 
+is omitted, the `latest` is assumed. 
+
+At the end of the install phase, we will have our image built and tagged in the docker host,
+now we can decide if we want to push on a remote docker registry. To push to a remote registry 
+we need actually to rename the image, because we need to add the namespace in front of it. So 
+we are going to reuse the `tag` goal again:
+
+```xml
+<execution>
+    <id>push-docker-image</id>
+    <phase>deploy</phase>
+    <goals>
+        <goal>tag</goal>
+    </goals>
+
+    <configuration>
+        <tagInfoFile>${project.build.directory}/docker_image_info.json</tagInfoFile>
+        <image>myuser/myapp:${project.version}</image>
+        <newName>quay.io/myuser/myapp:${project.version}</newName>
+        <pushImage>true</pushImage> <!-- We are also pushing this time -->
+    </configuration>
+</execution>
+```
+
+Since the [0.1.2 version, released today](https://github.com/spotify/docker-maven-plugin/issues/53#issuecomment-74712040), it is possible to specify the remote registry 
+credentials only using maven properties at the moments, but they are enough flexible to
+permit you using systen environment on your CI server for example.
+
+I must say Spotify has done a great job to delivery this plugin, in perfect accordance 
+with the open source spirit.
+
+
+
+
+

--- a/src/content/blog/2023-05-10-avro-schema-registry.md
+++ b/src/content/blog/2023-05-10-avro-schema-registry.md
@@ -1,0 +1,127 @@
+---
+title: "Harnessing the power of Avro and the Schema Registry"
+date: 2023-05-10
+tags: ["kafka", "avro", "schema-registry", "data"]
+excerpt: "Why Avro is worth the extra moving parts on Kafka, what the five bytes in front of every message are for, and how the serializer and the schema registry keep incompatible data off your topics."
+canonicalUrl: "https://medium.com/@filippodeluca/harnessing-the-power-of-avro-and-the-schema-registry-for-seamless-data-integration-4158403c7b49"
+---
+
+> Originally published on [Medium](https://medium.com/@filippodeluca/harnessing-the-power-of-avro-and-the-schema-registry-for-seamless-data-integration-4158403c7b49).
+
+When embarking on the journey of incorporating Kafka into your distributed architecture,
+one crucial decision is to choose a shared format among options like JSON, Protobuf,
+String, or Avro.
+
+Each format has its advantages and disadvantages. JSON is widely recognised and
+supported, which makes it a popular choice. Avro stands out for its schema evolution
+capability, enabling independent evolution of producer and consumer schemas within
+specified compatibility rules. Protobuf offers great flexibility, although it requires
+manual evolution of codecs.
+
+Selecting the appropriate format involves weighing familiarity, schema evolution needs,
+and flexibility against your specific requirements.
+
+## The Avro format
+
+Avro is a data serialization system developed by the Apache Software Foundation. It
+provides a compact and efficient way to serialize structured data for storage or
+transmission. It also supports schema evolution, meaning you can read data written with a
+newer schema version using an older one.
+
+Avro payloads can be encoded in either JSON or binary, but binary encoding is by far the
+more common. So when people talk about reading Avro, they typically mean reading
+binary-encoded Avro.
+
+Unlike JSON, which is schema-free and self-descriptive, **in Avro you need the schema in
+order to read the payload at all**. That single fact drives everything that follows.
+
+## Schema compatibility
+
+Compatibility between two schemas falls into one of these categories:
+
+- **Forward compatibility** — a payload written with a new schema can be read using an
+  older schema.
+- **Backward compatibility** — a payload written with an older schema can be read using a
+  newer schema.
+- **Full compatibility** — both of the above hold.
+
+To read an Avro payload correctly you need *two* schemas: the one the payload was written
+with, and the stable schema the reader expects. The Avro SDK uses both — it reads the
+payload with the writer schema and adapts it to the reader schema. That's what lets a
+consumer keep a consistent view of the data while schemas evolve underneath it.
+
+## The Kafka–Avro format
+
+A Kafka message consists of a key, a value, and a set of headers. The Avro serializer can
+encode the key, the value, or both.
+
+Since reading a payload requires knowing the schema it was written with, the Avro Kafka
+serializer uses a specific wire format with **five bytes of padding** in front of the
+payload:
+
+- The first byte — the *magic byte* — is always `0`. It marks the message as Avro
+  encoded, which is useful when a topic carries messages in more than one format (though
+  mixing formats on a topic is generally not a good idea).
+- The next four bytes hold the **schema ID** obtained from the schema registry.
+- The remainder is the actual content, in Avro binary encoding.
+
+This way an Avro-encoded message can be identified and decoded while carrying just enough
+schema information to do it.
+
+## The schema registry
+
+The schema registry, a component of the Confluent platform, manages and preserves Avro
+schemas and enforces the required compatibility level as they evolve.
+
+It introduces three concepts:
+
+- **Schema** — the Avro schema itself, defining structure and types.
+- **Subject** — the owner of a schema. In Kafka terms, it maps to either the key or the
+  value part of a topic's messages.
+- **Subject version** — each version captures the evolution of a subject over time, and
+  may be associated with a different schema.
+
+Note that **the relationship between a topic and its schemas exists only at the client
+level**. By convention the (de)serializer associates the value and key of a topic with a
+subject: the value of topic `foo` maps to subject `foo-value`.
+
+Whenever a subject is associated with a new schema its version is incremented, and the
+registry checks the new version against the previous one according to the compatibility
+level configured for that subject.
+
+## The schema dance
+
+Putting it together — here's how serializer, deserializer and registry interact.
+
+When a producer creates a message, the Avro serializer:
+
+1. Attempts to register the schema against the subject.
+2. Receives a new schema ID if the schema is compatible with the previous one; otherwise
+   it errors out.
+3. Encodes the payload with that schema ID, as described above.
+
+This happens only the first time the serializer meets a given schema — afterwards it uses
+the cached schema ID.
+
+When a consumer receives an Avro-encoded message, the deserializer:
+
+1. Extracts the schema ID from the payload.
+2. Fetches the corresponding schema from the registry.
+3. Decodes the payload using the local reader schema together with the downloaded writer
+   schema.
+
+Two guarantees fall out of this:
+
+- **It is impossible to write a message to Kafka with an incompatible schema.**
+- **Data on a topic is always associated with a schema.**
+
+## In closing
+
+Choosing the right data format for a Kafka-based architecture matters. Avro's schema
+evolution lets producer and consumer schemas move independently while staying within
+compatibility rules, so the system can grow without breaking the data contract.
+
+The schema registry is what makes that work in practice: it handles availability,
+versioning and compatibility control, and the serializer and deserializer lean on it to
+encode and decode transparently. Together they mean you can exchange data across topics
+knowing compatibility is enforced and every payload can still be read.

--- a/src/content/blog/2026-08-27-optimistic-locking-stops-at-the-region-border.md
+++ b/src/content/blog/2026-08-27-optimistic-locking-stops-at-the-region-border.md
@@ -9,9 +9,9 @@ draft: true
 Consider a record in a DynamoDB global table, replicated active-active across three
 regions. It has three fields:
 
-- `expiresAt` — a TTL, pushed forward whenever the client is active
-- `ownerId` — reassigned by a batch job
-- `attributes` — a metadata blob the client rewrites on every handshake
+- `leaseUntil` — a lease expiry, pushed forward whenever the client is active
+- `tenantId` — reassigned by a batch job
+- `settings` — a JSON blob written by more than one client
 
 Three fields, three systems writing them, none aware of the others. Every write is
 guarded by optimistic locking: a `version` attribute and a conditional update.
@@ -23,13 +23,21 @@ Writes still went missing.
 Optimistic locking works. Within a region.
 
 Global tables replicate asynchronously, and a conditional expression is evaluated
-against the **local** replica. Two regions can both read `version = 10`, both find the
-condition satisfied, and both write `version = 11`. Neither write fails. Neither client
-sees an error. There is nothing to retry, because as far as each region is concerned
-nothing went wrong.
+against the **local** replica. So two regions can both read `version = 10` and both find
+the condition satisfied:
+
+```
+region A   read v10 → set tenantId = T-9   → write v11   ✓ succeeds
+region B   read v10 → set leaseUntil = Nov → write v11   ✓ succeeds
+```
+
+Neither write fails. Neither client sees an error. There is nothing to retry, because as
+far as each region is concerned nothing went wrong — and note that the two are changing
+*different fields*, so there is no disagreement to resolve in the first place.
 
 Replication then reconciles two items that both claim to be version 11, using
-last-write-wins on the replication timestamp. One of them quietly disappears.
+last-write-wins on the replication timestamp. Whichever loses takes its field with it: the
+tenant reassignment or the lease extension is simply gone, and no one was ever told.
 
 The lock isn't broken. It answers a different question — "did anyone else in *this*
 region touch the row since I read it?" — and answers it correctly. Cross-region
@@ -42,22 +50,22 @@ being true.
 It's tempting to accept LWW as the price of active-active. Two things make that price
 higher than it looks.
 
-**LWW resolves items, not fields.** If one writer touches `expiresAt` and another
-touches `attributes`, the winning item carries its own stale copy of the field it never
+**LWW resolves items, not fields.** If one writer touches `leaseUntil` and another
+touches `settings`, the winning item carries its own stale copy of the field it never
 modified. You didn't lose a contested write — you lost an *uncontested* one. Two writers
 that were never in conflict, because they were changing different things, still clobber
 each other because those things happen to share an item.
 
-**LWW knows nothing about your domain.** `expiresAt` has an invariant: it only ever moves
-forward. Nothing in DynamoDB knows that. A delayed event carrying a shorter TTL has a
+**LWW knows nothing about your domain.** `leaseUntil` has an invariant: it only ever moves
+forward. Nothing in DynamoDB knows that. A delayed event carrying an earlier expiry has a
 later replication timestamp, so it wins — and the expiry moves backwards:
 
 ```
-T0                expiresAt = Oct 20
+T0                leaseUntil = Oct 20
 T1  region A      extend to Nov 20   (fresh, correct)
 T2  region B      extend to Oct 25   (delayed event, stale value)
 
-converged state:  expiresAt = Oct 25
+converged state:  leaseUntil = Oct 25
 ```
 
 Every replica agrees. Nothing is inconsistent. The system converged on a value that
@@ -84,16 +92,16 @@ the wrong half of the problem.
 
 ## Stop sharing the item
 
-Here's the thing worth noticing: the conflict between `expiresAt` and `attributes` isn't
+Here's the thing worth noticing: the conflict between `leaseUntil` and `settings` isn't
 a conflict at all. Nobody is disagreeing about a value. It's an artifact of the two fields
 sharing an item, and therefore sharing a version and a replication timestamp.
 
 So stop sharing:
 
 ```
-PK: Record#123  SK: #TTL          expiresAt
-PK: Record#123  SK: #Owner        ownerId
-PK: Record#123  SK: #Attributes   attributes
+PK: Record#123  SK: #Lease        leaseUntil
+PK: Record#123  SK: #Tenant       tenantId
+PK: Record#123  SK: #Settings     settings
 ```
 
 Each item gets its own version. Writers touching different fields now touch different
@@ -102,10 +110,9 @@ longer exist.
 
 The cost is real: reads amplify from one item to a query over the partition key, item
 count grows, and existing records need migrating. The gain is that an entire *class* of
-conflict is gone rather than mitigated. In our case that class was the overwhelming
-majority, because the highest-frequency path touched two of those fields at once — every
-handshake extended the TTL and rewrote the attributes in the same call, and every
-concurrent update from anywhere else landed on top of it.
+conflict is gone rather than mitigated — and that class is usually the bulk of the
+problem, because the highest-frequency path tends to touch several fields in one call
+while every other writer lands on top of it.
 
 **The cheapest conflict to resolve is the one you don't have.** Before building a
 reconciliation engine, it's worth asking whether the data that keeps colliding has any
@@ -115,8 +122,8 @@ during design, not because anything reads or writes it together.
 ## What's left is the real problem
 
 After splitting, what remains is genuine contention: **the same field, written by
-different sources**. Two TTL extensions from two different paths. Two patches to the same
-attribute from a client and from back-office tooling.
+different sources**. Two lease extensions from two different paths. Two patches to the same
+setting, one from a client and one from back-office tooling.
 
 No amount of remodelling makes that go away. Two writers really are disagreeing about one
 value, and something has to decide. The question is only whether that decision knows
@@ -126,15 +133,15 @@ anything about your domain.
 
 Two rungs on this ladder, and they cost very different amounts.
 
-**Per-field timestamps.** If `attributes` is a blob patched by several sources, store a
+**Per-field timestamps.** If `settings` is a blob patched by several sources, store a
 timestamp beside each field rather than for the item as a whole:
 
 ```json
 {
-  "appVersion": "7.21.0",
-  "appVersion_updatedAt": 1728045000,
-  "osVersion": "16",
-  "osVersion_updatedAt": 1728043000
+  "theme": "dark",
+  "theme_updatedAt": 1728045000,
+  "language": "en-GB",
+  "language_updatedAt": 1728043000
 }
 ```
 
@@ -143,17 +150,17 @@ per field — still arbitrary, but deterministic, and no longer taking the neigh
 fields down with it. This doubles the storage for the blob and needs no new
 infrastructure. For data with no invariants, it's usually enough.
 
-**Event sourcing, where an invariant exists.** For `expiresAt`, timestamps don't help.
+**Event sourcing, where an invariant exists.** For `leaseUntil`, timestamps don't help.
 The rule isn't "latest wins", it's "furthest forward wins", and no amount of ordering
 metadata expresses that.
 
 So write down intentions instead of states: an append-only log of events
-(`TTL_EXTENDED`, carrying the new value and its origin), plus a per-region materialised
+(`LeaseExtended`, carrying the new value and its origin), plus a per-region materialised
 view rebuilt from that log. Reconciliation is then free to encode the rule:
 
 ```scala
-def apply(state: State, e: TtlExtended): State =
-  state.copy(expiresAt = state.expiresAt max e.newExpiresAt)
+def apply(state: State, e: LeaseExtended): State =
+  state.copy(leaseUntil = state.leaseUntil max e.newLeaseUntil)
 ```
 
 `max` is commutative, associative and idempotent. Arrival order stops mattering.

--- a/src/content/blog/2026-08-27-optimistic-locking-stops-at-the-region-border.md
+++ b/src/content/blog/2026-08-27-optimistic-locking-stops-at-the-region-border.md
@@ -1,0 +1,187 @@
+---
+title: "Optimistic locking stops at the region border"
+date: 2026-08-27
+tags: ["dynamodb", "distributed-systems", "aws", "architecture"]
+excerpt: "A version check that passes in two regions at once isn't a broken lock — it's a lock answering a different question. What that costs you, and which conflicts are worth resolving versus modelling away."
+draft: true
+---
+
+Consider a record in a DynamoDB global table, replicated active-active across three
+regions. It has three fields:
+
+- `expiresAt` — a TTL, pushed forward whenever the client is active
+- `ownerId` — reassigned by a batch job
+- `attributes` — a metadata blob the client rewrites on every handshake
+
+Three fields, three systems writing them, none aware of the others. Every write is
+guarded by optimistic locking: a `version` attribute and a conditional update.
+
+Writes still went missing.
+
+## A version check that passes twice
+
+Optimistic locking works. Within a region.
+
+Global tables replicate asynchronously, and a conditional expression is evaluated
+against the **local** replica. Two regions can both read `version = 10`, both find the
+condition satisfied, and both write `version = 11`. Neither write fails. Neither client
+sees an error. There is nothing to retry, because as far as each region is concerned
+nothing went wrong.
+
+Replication then reconciles two items that both claim to be version 11, using
+last-write-wins on the replication timestamp. One of them quietly disappears.
+
+The lock isn't broken. It answers a different question — "did anyone else in *this*
+region touch the row since I read it?" — and answers it correctly. Cross-region
+concurrency simply isn't visible at the moment of commit. If your mental model is
+"the version check protects the record", the region border is where that model stops
+being true.
+
+## Last-write-wins is worse than it sounds
+
+It's tempting to accept LWW as the price of active-active. Two things make that price
+higher than it looks.
+
+**LWW resolves items, not fields.** If one writer touches `expiresAt` and another
+touches `attributes`, the winning item carries its own stale copy of the field it never
+modified. You didn't lose a contested write — you lost an *uncontested* one. Two writers
+that were never in conflict, because they were changing different things, still clobber
+each other because those things happen to share an item.
+
+**LWW knows nothing about your domain.** `expiresAt` has an invariant: it only ever moves
+forward. Nothing in DynamoDB knows that. A delayed event carrying a shorter TTL has a
+later replication timestamp, so it wins — and the expiry moves backwards:
+
+```
+T0                expiresAt = Oct 20
+T1  region A      extend to Nov 20   (fresh, correct)
+T2  region B      extend to Oct 25   (delayed event, stale value)
+
+converged state:  expiresAt = Oct 25
+```
+
+Every replica agrees. Nothing is inconsistent. The system converged on a value that
+violates the one rule the field had. That's not eventual consistency being eventual —
+it's an invariant being broken *and then replicated everywhere*, which is considerably
+harder to notice than a transient disagreement.
+
+## The fix that looks obvious and isn't
+
+The first instinct is to route: pin every write for a given record to a single region and
+the problem is gone.
+
+It holds for synchronous client traffic, where the source IP already determines the
+region. It falls apart for everything else:
+
+- async event consumers run wherever the consumer happens to be scheduled
+- batch jobs run from an arbitrary region
+- back-office operations originate wherever the operator is
+- clients roam, and their "home" region changes underneath them
+
+Routing covers the slice of traffic that was already the best behaved, and leaves every
+source that has no region affinity in the first place. It's not wrong, it's just aimed at
+the wrong half of the problem.
+
+## Stop sharing the item
+
+Here's the thing worth noticing: the conflict between `expiresAt` and `attributes` isn't
+a conflict at all. Nobody is disagreeing about a value. It's an artifact of the two fields
+sharing an item, and therefore sharing a version and a replication timestamp.
+
+So stop sharing:
+
+```
+PK: Record#123  SK: #TTL          expiresAt
+PK: Record#123  SK: #Owner        ownerId
+PK: Record#123  SK: #Attributes   attributes
+```
+
+Each item gets its own version. Writers touching different fields now touch different
+items and never interact — not because conflicts are resolved better, but because they no
+longer exist.
+
+The cost is real: reads amplify from one item to a query over the partition key, item
+count grows, and existing records need migrating. The gain is that an entire *class* of
+conflict is gone rather than mitigated. In our case that class was the overwhelming
+majority, because the highest-frequency path touched two of those fields at once — every
+handshake extended the TTL and rewrote the attributes in the same call, and every
+concurrent update from anywhere else landed on top of it.
+
+**The cheapest conflict to resolve is the one you don't have.** Before building a
+reconciliation engine, it's worth asking whether the data that keeps colliding has any
+reason to live together. Often it's sharing an item because it arrived at the same time
+during design, not because anything reads or writes it together.
+
+## What's left is the real problem
+
+After splitting, what remains is genuine contention: **the same field, written by
+different sources**. Two TTL extensions from two different paths. Two patches to the same
+attribute from a client and from back-office tooling.
+
+No amount of remodelling makes that go away. Two writers really are disagreeing about one
+value, and something has to decide. The question is only whether that decision knows
+anything about your domain.
+
+## Give the merge some domain knowledge
+
+Two rungs on this ladder, and they cost very different amounts.
+
+**Per-field timestamps.** If `attributes` is a blob patched by several sources, store a
+timestamp beside each field rather than for the item as a whole:
+
+```json
+{
+  "appVersion": "7.21.0",
+  "appVersion_updatedAt": 1728045000,
+  "osVersion": "16",
+  "osVersion_updatedAt": 1728043000
+}
+```
+
+Patches to different fields merge. Patches to the same field resolve by last-write-wins
+per field — still arbitrary, but deterministic, and no longer taking the neighbouring
+fields down with it. This doubles the storage for the blob and needs no new
+infrastructure. For data with no invariants, it's usually enough.
+
+**Event sourcing, where an invariant exists.** For `expiresAt`, timestamps don't help.
+The rule isn't "latest wins", it's "furthest forward wins", and no amount of ordering
+metadata expresses that.
+
+So write down intentions instead of states: an append-only log of events
+(`TTL_EXTENDED`, carrying the new value and its origin), plus a per-region materialised
+view rebuilt from that log. Reconciliation is then free to encode the rule:
+
+```scala
+def apply(state: State, e: TtlExtended): State =
+  state.copy(expiresAt = state.expiresAt max e.newExpiresAt)
+```
+
+`max` is commutative, associative and idempotent. Arrival order stops mattering.
+Duplicates stop mattering. Delayed events stop mattering — the stale one is absorbed with
+no effect rather than winning on a timestamp. Every region converges on the same value,
+and that value satisfies the invariant by construction.
+
+If that sounds like a CRDT, it is one: a grow-only register. You don't need the whole
+event-sourcing apparatus to get it, but once a field needs a merge function this specific,
+you need *somewhere* to put that function, and a log of intentions is a good place.
+
+The costs are not small — an events table, streams, consumers, monitoring, event schema
+evolution, and a migration. Which is exactly why I'd scope it to the fields that have an
+invariant, rather than to the whole record. Event sourcing here is the answer to "this
+merge needs to understand the domain", not to "we have a concurrency problem". Reaching
+for it because writes are being lost, when the writes were being lost because unrelated
+fields shared an item, is a lot of machinery bolted onto a modelling mistake.
+
+## The order I'd work in
+
+1. **Split by writer.** Group fields by what updates them, not by what reads them
+   together. Best effort-to-benefit ratio, and it makes everything after it smaller.
+2. **Measure what's left.** The remaining conflicts are usually far fewer, and far more
+   interesting, than the ones you started with.
+3. **Per-field timestamps** where merges are structurally independent.
+4. **Event sourcing** only where an invariant exists that last-write-wins can violate.
+
+The question isn't "which consistency pattern do we adopt". It's **which conflicts can I
+model away, and which do I actually have to resolve** — two different jobs, and the
+second one costs an order of magnitude more than the first. Most of the pain comes from
+paying that price for conflicts that were never real.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,6 +7,7 @@ const blog = defineCollection({
     date: z.coerce.date(),
     excerpt: z.string().optional(),
     tags: z.array(z.string()).default([]),
+    canonicalUrl: z.string().url().optional(),
     draft: z.boolean().default(false),
   }),
 });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,21 +4,24 @@ import '../styles/global.css';
 interface Props {
   title: string;
   description?: string;
+  canonical?: string;
 }
 
 const {
   title,
+  canonical,
   description = 'Filippo De Luca — software engineer. Scala, Cats Effect, distributed systems, and a background in mechanical engineering.',
 } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="it">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="description" content={description} />
+    {canonical && <link rel="canonical" href={canonical} />}
     <title>{title} · Filippo De Luca</title>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -20,7 +20,7 @@ const { Content } = await post.render();
 const dateFmt = new Intl.DateTimeFormat('en-GB', { year: 'numeric', month: 'long', day: '2-digit' });
 ---
 
-<BaseLayout title={post.data.title} description={post.data.excerpt}>
+<BaseLayout title={post.data.title} description={post.data.excerpt} canonical={post.data.canonicalUrl}>
   <article class="hero" style="padding-top: 3.5rem;">
     <span class="eyebrow">{dateFmt.format(post.data.date)}</span>
     <h1>{post.data.title}</h1>


### PR DESCRIPTION
The Hugo→Astro migration created the post files but never copied the bodies across. Every published post shipped as a stub containing only:

```
<!--
  TODO: paste the original post body here. ...
-->
```

The comment is also malformed in the rendered output, so `-->` shows up as visible text on the live pages. Two posts were dropped from the migration entirely.

Bodies are recovered verbatim from `content/posts` at `aedb282` — the last commit before the rewrite. Existing frontmatter is untouched.

## Restored

| Post | Was |
|---|---|
| REST method override filter (2010) | empty |
| GWT RPC Best Practices (2012) | empty |
| Pimping JSoup (2012) | empty |
| Round-Robin Iterable (2013) | empty |
| **Docker maven plugin (2015)** | **missing entirely** |

## Added

- **Harnessing the power of Avro and the Schema Registry (2023)** — only ever existed on Medium; the repo had a Hugo stub that was never filled in. Added here with `rel=canonical` pointing at the Medium original, so the two copies don't compete in search.
- **Optimistic locking stops at the region border (2026)** — new piece on multi-region concurrency. `draft: true`, so it does not appear on the site.

## Incidental fixes

- `canonicalUrl` added to the content schema and wired through `BaseLayout`, which had no canonical support.
- `<html lang="it">` → `lang="en"`. The site is entirely in English; the wrong language attribute hurts search engines and makes screen readers use Italian pronunciation.

Blog goes from 4 empty pages to 6 real posts, most recent 2023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)