### PR TITLE
Stop repeating the site name in the home page title

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,7 +18,10 @@ const {
   description = 'Filippo De Luca — software engineer. Scala, Cats Effect, distributed systems, and a background in mechanical engineering.',
 } = Astro.props;
 
-const fullTitle = `${title} · Filippo De Luca`;
+// The home page is already titled "Filippo De Luca"; appending the site
+// name there would print it twice.
+const SITE_NAME = 'Filippo De Luca';
+const fullTitle = title === SITE_NAME ? title : `${title} · ${SITE_NAME}`;
 // og:url always points here, even when rel=canonical credits an earlier
 // publication elsewhere: the two answer different questions.
 const pageUrl = new URL(Astro.url.pathname, Astro.site).href;
@@ -35,7 +38,7 @@ const imageUrl = new URL(image, Astro.site).href;
     {canonical && <link rel="canonical" href={canonical} />}
 
     <meta property="og:type" content={type} />
-    <meta property="og:site_name" content="Filippo De Luca" />
+    <meta property="og:site_name" content={SITE_NAME} />
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={pageUrl} />
@@ -46,7 +49,7 @@ const imageUrl = new URL(image, Astro.site).href;
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={imageUrl} />
-    <title>{title} · Filippo De Luca</title>
+    <title>{fullTitle}</title>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
`BaseLayout` appended `· Filippo De Luca` to every title unconditionally. On the home page — already titled `Filippo De Luca` — that rendered as:

```
Filippo De Luca · Filippo De Luca
```

in the browser tab, in search results, and in the `og:title` of every shared link. LinkedIn's Post Inspector shows it on the preview card.

Now the suffix is skipped when the title already is the site name. The `<title>` tag also uses the computed value instead of repeating the concatenation by hand.

Post titles are unaffected: `Harnessing the power of Avro and the Schema Registry · Filippo De Luca`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)